### PR TITLE
Replace base64 dependency with cl-base64

### DIFF
--- a/src/crud/crud.asd
+++ b/src/crud/crud.asd
@@ -5,7 +5,7 @@
   :depends-on
   (#:sucle-serialize
    #:sqlite
-   #:base64
+   #:cl-base64
    #:uiop
    #:lparallel
    ;;For one macro in 'database'
@@ -13,7 +13,7 @@
   :serial t
   :components
   ((:file "database")
-   (:file "crud"))) 
+   (:file "crud")))
 
 
 

--- a/src/crud/crud.lisp
+++ b/src/crud/crud.lisp
@@ -91,14 +91,10 @@
 ;;[FIXME]:can possibly create filenames that are illegal.
 ;;use base64 instead? how to mix the two?
 ;;
-(defparameter *base-64-string*
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
 (defun string-base64 (string)
-  (let ((base64::*base64* *base-64-string*))
-    (base64:base64-encode string)))
+  (base64:string-to-base64-string string :uri t))
 (defun base64-string (string)
-  (let ((base64::*base64* *base-64-string*))
-    (base64:base64-decode string)))
+  (base64:base64-string-to-string string :uri t))
 (defun commentify (&optional (string "test"))
   (concatenate 'string ";" string))
 (defun un-commentify (&optional (string ";test"))
@@ -116,7 +112,7 @@
 				     directory)))
   ;;FIXME::This probably won't work on windows.
   ;;https://stackoverflow.com/questions/4814040/allowed-characters-in-filename
-  
+
   ;;Check that they both point to files in same directory
   ;;If they are, then it is safe
   (if (equal (pathname-directory base64-path)
@@ -129,7 +125,7 @@
 (defun crud_read_file-pile (lisp-object &aux (path *path*))
   (multiple-value-bind (file-path base64) (%check-safe-string lisp-object path)
     ;;if both are valid, prefer the base64 one.
-    ;;if only base64 is valid, just use that.  
+    ;;if only base64 is valid, just use that.
     (sucle-serialize:load
      (cond (file-path
 	    (if (probe-file base64)


### PR DESCRIPTION
Quicklisp has four systems with 'base64' in the name, the most popular
of which is cl-base64, which has 56 immediate dependencies. The base64
system has a package collision with cl-base64: the name of the former's
package and the nickname of the latter's is both base64.

This commit replaces base64 with cl-base64, so that the crud system can
be loaded on the same image as the system, its 56 immediate
dependencies, and all its dependencies thereafter.